### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/branch_release_deleter.yaml
+++ b/.github/workflows/branch_release_deleter.yaml
@@ -7,7 +7,7 @@ jobs:
   delete_release:
     runs-on: ubuntu-latest
     steps:
-    - name: Delete non-master branch release
+    - name: Delete non-main branch release
       uses: author/action-rollback@stable
       with:
         tag: draft-assets-for-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -46,8 +46,8 @@ jobs:
     - name: Run model
       run: docker run --mount source=${{ github.workspace }},dst=/workspace,type=bind docker.opensafely.org/stata-mp analysis/model.do
 
-    - name: Create pre-release if on non-master branch
-      if: github.ref != 'master'
+    - name: Create pre-release if on non-main branch
+      if: github.ref != 'main'
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,8 +57,8 @@ jobs:
         prerelease: true
         files: |
           ./output/input*csv
-    - name: Create full release if on master branch
-      if: github.ref == 'master' || github.pull_request.merged == true
+    - name: Create full release if on main branch
+      if: github.ref == 'main' || github.pull_request.merged == true
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For more information on why we're renaming master to main, see: opensafely/research-template#32.

There are two Stata files that contain references to `master`, but I don't think they're references to the master branch. I'd appreciate a second opinion, though:

https://github.com/opensafely/hiv-research/blob/e5ad20e28bb116ee9b0100a87e8becbebcdd1e60/analysis/adofiles/stpm2_pred.ado#L2286-L2292

https://github.com/opensafely/hiv-research/blob/e5ad20e28bb116ee9b0100a87e8becbebcdd1e60/analysis/cr_matchedcohort.do#L17-L21